### PR TITLE
fix tests for `multipart 1.x`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ CHANGES
 6.1 (unreleased)
 ================
 
-- Nothing changed yet.
+- Make tests compatible with ``multipart 1.x``
+  (`#13 <https://github.com/zopefoundation/zope.app.form/issues/13>`_).
 
 
 6.0 (2023-02-24)

--- a/src/zope/app/form/browser/tests/test_functional_i18n.py
+++ b/src/zope/app/form/browser/tests/test_functional_i18n.py
@@ -85,6 +85,7 @@ def test_suite():
             query_str = query_str.lstrip()
             if not isinstance(query_str, bytes):
                 query_str = query_str.encode("ascii")
+            query_str = b"\r\n".join(query_str.splitlines())
             response = http(wsgi_app, query_str, *args, **kwargs)
             return response
 


### PR DESCRIPTION
Fixes #13.

`multipart 1.x` insists on `\r\n` line separators. Adapt our tests accordingly.