### PR TITLE
Update tests to run with `multipart >= 1.1+`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ CHANGES
 6.2 (unreleased)
 ================
 
-- Nothing changed yet.
+- Update tests to run with ``multipart >= 1.1+``.
 
 
 6.1 (2024-10-21)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ tests_require = [
     'zope.app.appsetup',
     'zope.testing',
     'zope.testrunner',
-    'zope.app.wsgi >= 5.2',
+    'zope.app.wsgi >= 5.3',
     'webtest',
 ]
 

--- a/src/zope/app/form/browser/editview.py
+++ b/src/zope/app/form/browser/editview.py
@@ -14,7 +14,8 @@
 """Edit View Classes"""
 __docformat__ = 'restructuredtext'
 
-from datetime import datetime
+import datetime
+import sys
 
 import transaction
 import zope.component
@@ -35,6 +36,9 @@ from zope.app.form.browser.i18n import _
 from zope.app.form.browser.submit import Update
 from zope.app.form.utility import applyWidgetsChanges
 from zope.app.form.utility import setUpEditWidgets
+
+
+PY310 = sys.version_info < (3, 11)
 
 
 class EditView(BrowserView):
@@ -112,9 +116,14 @@ class EditView(BrowserView):
                     self.changed()
                     formatter = self.request.locale.dates.getFormatter(
                         'dateTime', 'medium')
+                    if PY310:
+                        now = datetime.datetime.now(datetime.timezone.utc)
+                    else:
+                        now = datetime.datetime.now(datetime.UTC)
+
                     status = _("Updated on ${date_time}",
                                mapping={'date_time':
-                                        formatter.format(datetime.utcnow())})
+                                        formatter.format(now)})
 
         self.update_status = status
         return status

--- a/src/zope/app/form/browser/i18n.rst
+++ b/src/zope/app/form/browser/i18n.rst
@@ -8,7 +8,7 @@ i18n messages in the schema.
 
 Let's take this simple add form...
 
-  >>> print(http(r"""
+  >>> print(http(b"""
   ... GET /addfieldcontent.html HTTP/1.1
   ... """, handle_errors=False))
   HTTP/1.1 200 Ok
@@ -16,33 +16,19 @@ Let's take this simple add form...
 
 with an error...
 
-  >>> print(http(r"""
+  >>> content_type, content = encodeMultipartFormdata([
+  ...     ('field.title', ''),
+  ...     ('field.description', ''),
+  ...     ('field.somenumber', '0'),
+  ...     ('UPDATE_SUBMIT', 'Hinzufxgen'),
+  ...     ('add_input_name', ''),
+  ...     ])
+  >>> print(http(b"""
   ... POST /addfieldcontent.html HTTP/1.1
-  ... Content-Length: 670
-  ... Content-Type: multipart/form-data; boundary=---------------------------19588947601368617292863650127
+  ... Content-Type: %b
   ...
-  ... -----------------------------19588947601368617292863650127
-  ... Content-Disposition: form-data; name="field.title"
-  ...
-  ...
-  ... -----------------------------19588947601368617292863650127
-  ... Content-Disposition: form-data; name="field.description"
-  ...
-  ...
-  ... -----------------------------19588947601368617292863650127
-  ... Content-Disposition: form-data; name="field.somenumber"
-  ...
-  ... 0
-  ... -----------------------------19588947601368617292863650127
-  ... Content-Disposition: form-data; name="UPDATE_SUBMIT"
-  ...
-  ... Hinzufxgen
-  ... -----------------------------19588947601368617292863650127
-  ... Content-Disposition: form-data; name="add_input_name"
-  ...
-  ...
-  ... -----------------------------19588947601368617292863650127--
-  ... """, handle_errors=False))
+  ... %b
+  ... """ % (content_type, content), handle_errors=False))
   HTTP/1.1 200 Ok
   ...
             There are <strong>1</strong> input errors.
@@ -54,7 +40,7 @@ Translated
 
 And now the add form in German:
 
-  >>> print(http(r"""
+  >>> print(http(b"""
   ... GET /addfieldcontent.html HTTP/1.1
   ... Accept-Language: de
   ... """, handle_errors=False))
@@ -67,34 +53,20 @@ And now the add form in German:
 
 The same with an input error:
 
-  >>> print(http(r"""
+  >>> content_type, content = encodeMultipartFormdata([
+  ...     ('field.title', ''),
+  ...     ('field.description', ''),
+  ...     ('field.somenumber', '0'),
+  ...     ('UPDATE_SUBMIT', 'Hinzufxgen'),
+  ...     ('add_input_name', ''),
+  ...     ])
+  >>> print(http(b"""
   ... POST /addfieldcontent.html HTTP/1.1
   ... Accept-Language: de
-  ... Content-Length: 670
-  ... Content-Type: multipart/form-data; boundary=---------------------------19588947601368617292863650127
+  ... Content-Type: %b
   ...
-  ... -----------------------------19588947601368617292863650127
-  ... Content-Disposition: form-data; name="field.title"
-  ...
-  ...
-  ... -----------------------------19588947601368617292863650127
-  ... Content-Disposition: form-data; name="field.description"
-  ...
-  ...
-  ... -----------------------------19588947601368617292863650127
-  ... Content-Disposition: form-data; name="field.somenumber"
-  ...
-  ... 0
-  ... -----------------------------19588947601368617292863650127
-  ... Content-Disposition: form-data; name="UPDATE_SUBMIT"
-  ...
-  ... Hinzufxgen
-  ... -----------------------------19588947601368617292863650127
-  ... Content-Disposition: form-data; name="add_input_name"
-  ...
-  ...
-  ... -----------------------------19588947601368617292863650127--
-  ... """, handle_errors=False))
+  ... %b
+  ... """ % (content_type, content), handle_errors=False))
   HTTP/1.1 200 Ok
   ...Felderinhalt hinzuf...
   ...<strong>1</strong>...

--- a/src/zope/app/form/browser/tests/test_functional_i18n.py
+++ b/src/zope/app/form/browser/tests/test_functional_i18n.py
@@ -18,6 +18,7 @@ import re
 import unittest
 
 from persistent import Persistent
+from zope.app.wsgi.testlayer import encodeMultipartFormdata
 from zope.app.wsgi.testlayer import http
 from zope.i18nmessageid import MessageFactory
 from zope.interface import Interface
@@ -81,14 +82,10 @@ def test_suite():
         wsgi_app = AppFormLayer.make_wsgi_app()
 
         def _http(query_str, *args, **kwargs):
-            # Strip leading \n
-            query_str = query_str.lstrip()
-            if not isinstance(query_str, bytes):
-                query_str = query_str.encode("ascii")
-            response = http(wsgi_app, query_str, *args, **kwargs)
-            return response
+            return http(wsgi_app, query_str, *args, **kwargs)
 
         test.globs['http'] = _http
+        test.globs['encodeMultipartFormdata'] = encodeMultipartFormdata
 
     i18n = doctest.DocFileSuite('../i18n.rst',
                                 setUp=setUp,


### PR DESCRIPTION
Fix deprecation warning regarding `datetime.utcnow`.